### PR TITLE
Add the dbus-x11 package which includes dbus-launch

### DIFF
--- a/scripts/guest/setups/debian.sh
+++ b/scripts/guest/setups/debian.sh
@@ -76,7 +76,7 @@ apt update
 
 # install xfce-desktop
 echo "[+] installing xfce4"
-apt install -y sudo xfce4 onboard # Xephyr # Xephyr allow to run a display manager and rotate the screen from the container however it disable multitouch
+apt install -y sudo xfce4 onboard dbus-x11 # Xephyr # Xephyr allow to run a display manager and rotate the screen from the container however it disable multitouch
 
 # mask unused services
 systemctl mask lightdm


### PR DESCRIPTION
Hi guys, 

This adds the `dbus-launch` binary needed by `start_desktop.sh`. Without it, the X session displays an error message (dbus-launch not found) and exits.