### PR TITLE
Add support for new user names in SFOS >3.4

### DIFF
--- a/service/daemon.py
+++ b/service/daemon.py
@@ -20,7 +20,7 @@ class ContainersService(dbus.service.Object):
         dbus.service.Object.__init__(self, conn, object_path, bus_name)
 
         # daemon config
-        self.user_name = "nemo"
+        self.user_name = $USER
         self.user_uid  = 100000
         self.current_path = pathlib.Path(__file__).parent.parent.absolute()
 


### PR DESCRIPTION
Better late than never! Credits to Piggz who made me realize this environment variable even existed, which should make the daemon work with all SFOS versions without some dirty `ifelse` magic.

Hopefully I didn't forget something that would break the daemon (I don't have spare SFOS device to test at the moment), please let me know otherwise.