### PR TITLE
Disable Sailjail

### DIFF
--- a/harbour-containers.desktop
+++ b/harbour-containers.desktop
@@ -10,3 +10,6 @@ Name=Containers
 # Remember to comment out the following line, if you do not want to use
 # a different app name in German locale (de).
 Name[de]=Containers
+
+[X-Sailjail]
+Sandboxing=Disabled


### PR DESCRIPTION
On Sailfish >=4.3, the Container gridview is completely empty due to sandboxing. 

This fixes this problem as it allows the app to communicate with the daemons.